### PR TITLE
Expire WikiProjects list after 1 week

### DIFF
--- a/src/modules/submissions.js
+++ b/src/modules/submissions.js
@@ -1431,7 +1431,7 @@
 					} );
 
 					// If possible, cache the WikiProject data!
-					if ( !mw.storage.setObject( lskey, wikiProjects, ( 7 * 24 * 60 * 60 ) ) ) {
+					if ( !mw.storage.setObject( lsKey, wikiProjects, ( 7 * 24 * 60 * 60 ) ) ) {
 						AFCH.log( 'Unable to cache WikiProject list.' );
 					}
 

--- a/src/modules/submissions.js
+++ b/src/modules/submissions.js
@@ -1413,11 +1413,10 @@
 			var deferred = $.Deferred(),
 				wikiProjects = [],
 				// This is so a new version of AFCH will invalidate the WikiProject cache
-				lsKey = 'afch-' + AFCH.consts.version + '-wikiprojects-2';
+				lsKey = 'mw-afch-' + AFCH.consts.version + '-wikiprojects-2';
 
-			if ( window.localStorage && window.localStorage[ lsKey ] && window.localStorage[ lsKey + '-exp' ] &&
-				( window.localStorage[ lsKey + '-exp' ] > Date.now() ) ) {
-				wikiProjects = JSON.parse( window.localStorage[ lsKey ] );
+			if ( mw.storage.getObject( lsKey ) ) {
+				wikiProjects = mw.storage.getObject( lskey );
 				deferred.resolve( wikiProjects );
 			} else {
 				$.ajax( {
@@ -1432,13 +1431,8 @@
 					} );
 
 					// If possible, cache the WikiProject data!
-					if ( window.localStorage ) {
-						try {
-							window.localStorage[ lsKey ] = JSON.stringify( wikiProjects );
-							window.localStorage[ lsKey + '-exp' ] = Date.now() + ( 7 * 24 * 60 * 60 * 1000 );
-						} catch ( e ) {
-							AFCH.log( 'Unable to cache WikiProject list: ' + e.message );
-						}
+					if ( !mw.storage.setObject( lskey, wikiProjects, ( 7 * 24 * 60 * 60 ) ) ) {
+						AFCH.log( 'Unable to cache WikiProject list.' );
 					}
 
 					deferred.resolve( wikiProjects );

--- a/src/modules/submissions.js
+++ b/src/modules/submissions.js
@@ -1415,7 +1415,8 @@
 				// This is so a new version of AFCH will invalidate the WikiProject cache
 				lsKey = 'afch-' + AFCH.consts.version + '-wikiprojects-2';
 
-			if ( window.localStorage && window.localStorage[ lsKey ] ) {
+			if ( window.localStorage && window.localStorage[ lsKey ] && window.localStorage[ lsKey + '-exp' ] &&
+				( window.localStorage[ lsKey + '-exp' ] > Date.now() ) ) {
 				wikiProjects = JSON.parse( window.localStorage[ lsKey ] );
 				deferred.resolve( wikiProjects );
 			} else {
@@ -1434,6 +1435,7 @@
 					if ( window.localStorage ) {
 						try {
 							window.localStorage[ lsKey ] = JSON.stringify( wikiProjects );
+							window.localStorage[ lsKey + '-exp' ] = Date.now() + ( 7 * 24 * 60 * 60 * 1000 );
 						} catch ( e ) {
 							AFCH.log( 'Unable to cache WikiProject list: ' + e.message );
 						}

--- a/src/modules/submissions.js
+++ b/src/modules/submissions.js
@@ -1411,14 +1411,14 @@
 		 */
 		function loadWikiProjectList() {
 			var deferred = $.Deferred(),
-				wikiProjects = [],
 				// This is so a new version of AFCH will invalidate the WikiProject cache
-				lsKey = 'mw-afch-' + AFCH.consts.version + '-wikiprojects-2';
+				lsKey = 'mw-afch-' + AFCH.consts.version + '-wikiprojects-2',
+				wikiProjects = mw.storage.getObject( lsKey );
 
-			if ( mw.storage.getObject( lsKey ) ) {
-				wikiProjects = mw.storage.getObject( lskey );
+			if ( wikiProjects ) {
 				deferred.resolve( wikiProjects );
 			} else {
+				wikiProjects = [];
 				$.ajax( {
 					url: mw.config.get( 'wgServer' ) + '/w/index.php?title=Wikipedia:WikiProject_Articles_for_creation/WikiProject_templates.json&action=raw&ctype=text/json',
 					dataType: 'json'


### PR DESCRIPTION
~~Fixes 215~~
Adds 1-week expiration date for cached WikiProject list to match 1-week expiration schedule (the current code only refreshes the cache when the version number is updated, and it never actually removes the old cache which can cause the localstorage quota to fill up).