### PR TITLE
ci: split unit tests and linter into separate runners

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,0 +1,16 @@
+name: Linter
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - run: npm install
+    - run: npm run teststyle
+      name: AFCH linter

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -89,7 +89,7 @@ module.exports = function ( grunt ) {
 	grunt.registerTask(
 		'test',
 		'Runs unit tests as well as checks code style/quality.',
-		[ 'teststyle', 'exec:jest' ]
+		[ 'exec:jest' ]
 	);
 
 	grunt.registerTask(

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "scripts": {
     "test": "grunt test",
+    "teststyle": "grunt teststyle",
     "generate-certificates": "node scripts/generate-certificates.js"
   },
   "dependencies": {


### PR DESCRIPTION
In the event of continuous integration failure on a pull request, makes it easier to see what the problem is.